### PR TITLE
Set min size for profile photo

### DIFF
--- a/src/components/Kweet/index.tsx
+++ b/src/components/Kweet/index.tsx
@@ -23,6 +23,8 @@ const Container = styled.article`
 const ProfilePhoto = styled.img`
   width: 50px;
   height: 50px;
+  min-height: 50px;
+  min-width: 50px;
   border-radius: 50%;
 `;
 


### PR DESCRIPTION
Relates to #4 

Fixes the issue of profile photo being squished when Kweet content area is large for longer Kweets

## Before
<img width="415" alt="Screenshot 2022-03-26 at 14 17 58" src="https://user-images.githubusercontent.com/32060873/160243586-5494f2cc-dfc6-4c85-b1ff-84fd7e13b309.png">

## After
<img width="420" alt="Screenshot 2022-03-26 at 14 19 07" src="https://user-images.githubusercontent.com/32060873/160243627-bc160ce0-3668-4451-b8e5-158f3382358e.png">

