### PR TITLE
Add ㅋwitter home button and some navigation menu items

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-regular-svg-icons": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.1.18",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import App from './App';
+import { render, screen } from './testUtils';
 
 test('renders learn react link', () => {
   render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ function App(): React.ReactElement {
             selectedIcon={<FontAwesomeIcon size="lg" icon={homeSelected} />}
             text="Home"
           />
-
           <NavItem
             path="/notifications"
             defaultIcon={<FontAwesomeIcon size="lg" icon={bellDefault} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,24 @@
+import {
+  faBell as bellDefault,
+  faBookmark as bookmarkDefault,
+  faEnvelope as messageDefault,
+  faUser as userDefault
+} from '@fortawesome/free-regular-svg-icons';
+import {
+  faBell as bellSelected,
+  faBookmark as bookmarkSelected,
+  faEnvelope as messageSelected,
+  faHouse as homeDefault,
+  faHouseChimney as homeSelected,
+  faUser as userSelected
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
-import { BrowserRouter as Router, Link, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { HomeButton } from './components/HomeButton';
+import { NavItem } from './components/NavItem';
 import Home from './pages/Home';
 import Profile from './pages/Profile';
 
@@ -10,6 +27,10 @@ const Container = styled.div`
 `;
 
 const StyledNav = styled.nav`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
   min-width: 200px;
 `;
 
@@ -19,14 +40,38 @@ function App(): React.ReactElement {
       <Container>
         {/* TODO: Consolidate to component for navigation */}
         <StyledNav>
-          <ul>
-            <li>
-              <Link to="/">Home</Link>
-            </li>
-            <li>
-              <Link to="/profile">Profile</Link>
-            </li>
-          </ul>
+          <HomeButton />
+          <NavItem
+            path="/"
+            defaultIcon={<FontAwesomeIcon size="lg" icon={homeDefault} />}
+            selectedIcon={<FontAwesomeIcon size="lg" icon={homeSelected} />}
+            text="Home"
+          />
+
+          <NavItem
+            path="/notifications"
+            defaultIcon={<FontAwesomeIcon size="lg" icon={bellDefault} />}
+            selectedIcon={<FontAwesomeIcon size="lg" icon={bellSelected} />}
+            text="Notifications"
+          />
+          <NavItem
+            path="/messages"
+            defaultIcon={<FontAwesomeIcon size="lg" icon={messageDefault} />}
+            selectedIcon={<FontAwesomeIcon size="lg" icon={messageSelected} />}
+            text="Messages"
+          />
+          <NavItem
+            path="/bookmarks"
+            defaultIcon={<FontAwesomeIcon size="lg" icon={bookmarkDefault} />}
+            selectedIcon={<FontAwesomeIcon size="lg" icon={bookmarkSelected} />}
+            text="Bookmarks"
+          />
+          <NavItem
+            path="/profile"
+            defaultIcon={<FontAwesomeIcon size="lg" icon={userDefault} />}
+            selectedIcon={<FontAwesomeIcon size="lg" icon={userSelected} />}
+            text="Profile"
+          />
         </StyledNav>
         <Switch>
           <Route path="/profile">

--- a/src/components/HomeButton/index.tsx
+++ b/src/components/HomeButton/index.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import KwitterFavIcon from '../..//assets/kwitter_logo_favicon.png';
+
+const Logo = styled.img`
+  height: 35px;
+  width: 35px;
+`;
+
+const StyledLink = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 50%;
+  padding: 7px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.lightBlue};
+  }
+`;
+
+export function HomeButton() {
+  return (
+    <StyledLink to="/">
+      <Logo src={KwitterFavIcon} />
+    </StyledLink>
+  );
+}

--- a/src/components/HomeButton/index.tsx
+++ b/src/components/HomeButton/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import KwitterFavIcon from '../..//assets/kwitter_logo_favicon.png';
+import KwitterFavIcon from '../../assets/kwitter_logo_favicon.png';
 
 const Logo = styled.img`
   height: 35px;

--- a/src/components/NavItem/index.tsx
+++ b/src/components/NavItem/index.tsx
@@ -10,7 +10,7 @@ interface NavItemProps {
   text: string;
 }
 
-const Icon = styled.div`
+const IconWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -55,7 +55,7 @@ export function NavItem({
 
   return (
     <StyledLink to={path} $selected={isCurrentPath}>
-      <Icon>{isCurrentPath ? selectedIcon : defaultIcon}</Icon>
+      <IconWrapper>{isCurrentPath ? selectedIcon : defaultIcon}</IconWrapper>
       <Text>{text}</Text>
     </StyledLink>
   );

--- a/src/components/NavItem/index.tsx
+++ b/src/components/NavItem/index.tsx
@@ -1,0 +1,62 @@
+import { Link, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { Paths } from '../../paths';
+
+interface NavItemProps {
+  path: Paths;
+  defaultIcon: React.ReactNode;
+  selectedIcon: React.ReactNode;
+  text?: string;
+}
+
+const Icon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  height: 35px;
+  width: 35px;
+
+  border-radius: 50%;
+`;
+
+const StyledLink = styled(Link)<{ isCurrentPath: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  border-radius: 9999px;
+  padding: 7px;
+  min-height: 50px;
+
+  text-decoration: none;
+  color: ${({ theme }) => theme.colors.black};
+  font-weight: ${(props) => (props.isCurrentPath ? 'bolder' : 'normal')};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.grey[200]};
+  }
+`;
+
+const Text = styled.span`
+  padding: 0 15px;
+`;
+
+export function NavItem({
+  path,
+  defaultIcon,
+  selectedIcon,
+  text
+}: NavItemProps): JSX.Element {
+  const { pathname: currentPath } = useLocation();
+
+  const isCurrentPath = path === currentPath;
+
+  return (
+    <StyledLink to={path} isCurrentPath={isCurrentPath}>
+      <Icon>{isCurrentPath ? selectedIcon : defaultIcon}</Icon>
+      {text && <Text>{text}</Text>}
+    </StyledLink>
+  );
+}

--- a/src/components/NavItem/index.tsx
+++ b/src/components/NavItem/index.tsx
@@ -7,7 +7,7 @@ interface NavItemProps {
   path: Paths;
   defaultIcon: React.ReactNode;
   selectedIcon: React.ReactNode;
-  text?: string;
+  text: string;
 }
 
 const Icon = styled.div`
@@ -21,7 +21,7 @@ const Icon = styled.div`
   border-radius: 50%;
 `;
 
-const StyledLink = styled(Link)<{ isCurrentPath: boolean }>`
+const StyledLink = styled(Link)<{ $selected: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -32,7 +32,7 @@ const StyledLink = styled(Link)<{ isCurrentPath: boolean }>`
 
   text-decoration: none;
   color: ${({ theme }) => theme.colors.black};
-  font-weight: ${(props) => (props.isCurrentPath ? 'bolder' : 'normal')};
+  font-weight: ${(props) => (props.$selected ? 'bolder' : 'normal')};
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.grey[200]};
@@ -54,9 +54,9 @@ export function NavItem({
   const isCurrentPath = path === currentPath;
 
   return (
-    <StyledLink to={path} isCurrentPath={isCurrentPath}>
+    <StyledLink to={path} $selected={isCurrentPath}>
       <Icon>{isCurrentPath ? selectedIcon : defaultIcon}</Icon>
-      {text && <Text>{text}</Text>}
+      <Text>{text}</Text>
     </StyledLink>
   );
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,6 @@
+export type Paths =
+  | '/'
+  | '/notifications'
+  | '/messages'
+  | '/bookmarks'
+  | '/profile';

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 export const theme = {
   colors: {
     blue: '#1DA1F2',
+    lightBlue: '#E8F5FD',
     black: '#14171A',
     grey: {
       '400': '#657786',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,6 +1310,39 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"
+  integrity sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==
+
+"@fortawesome/fontawesome-svg-core@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz#3424ec6182515951816be9b11665d67efdce5b5f"
+  integrity sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.1"
+
+"@fortawesome/free-regular-svg-icons@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz#3f2f58262a839edf0643cbacee7a8a8230061c98"
+  integrity sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.1"
+
+"@fortawesome/free-solid-svg-icons@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz#3369e673f8fe8be2fba30b1ec274d47490a830a6"
+  integrity sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.1"
+
+"@fortawesome/react-fontawesome@^0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz#dae37f718a24e14d7a99a5496c873d69af3fbd73"
+  integrity sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==
+  dependencies:
+    prop-types "^15.8.1"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -9617,6 +9650,15 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -9845,7 +9887,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
Part of #23.

## Changes
- Added packages for font awesome icons (They seemed to contain the icons that are most closely resembling Look and feel of Twitter)
- Added Home button to the sidebar
- Added navigation menu items to the sidebar
  - **Note:** Navigation menu items pointing to paths with currently no corresponding page will default to 'Home'

Layout changes will follow 🙂 

<img width="238" alt="Screenshot 2022-05-03 at 15 31 05" src="https://user-images.githubusercontent.com/32060873/166401494-daee503e-5f49-4dc4-bbc1-bfe7e53ed09f.png">



